### PR TITLE
Fix byte-compile warning

### DIFF
--- a/plus-minus.el
+++ b/plus-minus.el
@@ -62,6 +62,7 @@
 ;;; Code:
 
 (require 'rx)
+(require 'rect)
 
 (defgroup plus-minus nil
   "plus/minus items."


### PR DESCRIPTION
```
plus-minus.el:356:1:Warning: the function ‘extract-rectangle-bounds’ is not
    known to be defined.
```